### PR TITLE
Trigger udev update to apply new rules without reboot

### DIFF
--- a/kmod_manager/kmodManager.bash
+++ b/kmod_manager/kmodManager.bash
@@ -142,6 +142,15 @@ function put_udev_rule(){
     printf "Put the udev rule : %s in %s to be accessible via an user.\n" "$rule" "$target";
     printf_tee "$rule" "$target";
     cat_file ${target}
+    
+#trigger update of udev rules without reboot (William Ledda)
+	if [ -f /bin/udevadm ]; then
+		echo "Triggering online rules update"
+		/bin/udevadm trigger
+	else
+		echo "No udevadm found. Reboot your system to apply new rules!"
+	fi
+	    
     __end_func ${func_name};
 }
 


### PR DESCRIPTION
Hi Han, 
I fixed kmod_manager script to update rules without reboot, running ``/bin/udevadm trigger`` at the end.